### PR TITLE
javascript-python 연결 test code 성공

### DIFF
--- a/server/routes/mypage.js
+++ b/server/routes/mypage.js
@@ -3,12 +3,22 @@ import { ChildProcess } from "child_process";
 
 const router = express.Router();
 
+// child process 의 spawn이 가져와지지 않는다.
+// ES6 관련 이슈인가 싶어 module 모듈의 createRequire 기능을 사용
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const spawner = require("child_process").spawn;
+
 /* GET users listing. */
 router.get("/", async (req, res, next) => {
   // 1. child-process모듈의 spawn 취득
-  const { spawn } = ChildProcess;
+  // const spawner = ChildProcess.spawn;
+
   // 2. spawn을 통해 "python 파이썬파일.py" 명령어 실행
-  const result = spawn("python", ["./test/test.py", "강낭콩"]);
+  const result = spawner("python", [
+    "/Users/soyeonnoh/Desktop/2022_workspace/Bodapet/test/test.py",
+  ]);
+  // const result = spawn("python", ["../../test/test.py", "강낭콩"]);
   // 3. stdout의 'data'이벤트리스너로 실행결과를 받는다.
   result.stdout.on("data", function (data) {
     console.log("python code 실행결과", data.toString());

--- a/test/test.py
+++ b/test/test.py
@@ -1,9 +1,10 @@
+# -*- coding: utf8 -*-
 import sys
 
 print('파이썬 파일에 접근했습니다.')
 
-def func1(a):
-    print('저는',a,'입니다')
+# def func1(a):
+#     print('저는',a,'입니다')
 
 
 
@@ -22,5 +23,5 @@ def func1(a):
 # def main(**vars(opt)):
 #     print('성공')
 
-if __name__ == '__main__':
-    func1(sys.argv[1])
+# if __name__ == '__main__':
+#     func1(sys.argv[1])


### PR DESCRIPTION
- child_process 모듈의 child_process.spawn 이 제대로 가져와지지 않았던 것이 문제.
- 별도의 test 코드에서 `const spawner = require("child_process").spawn;`이 잘 작동한 것을 확인
- import {createRequire} from "module" 모듈을 사용하여 ES6 이전의 import 문법으로 작성하여 문제를 해결